### PR TITLE
installation: docker and dependency fixes

### DIFF
--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -8,13 +8,18 @@
 Installation
 ============
 
-The installation process is very similar to standard Invenio
-installation:
+You can run a local CERN Open Data instance for development purposes using
+Docker:
 
-* http://invenio.readthedocs.org/en/latest/developers/docker.html
+.. code-block:: console
 
-Please note that populating the site with records might take
-considerable time (30 minutes or more).
+   $ docker-compose build
+   $ docker-compose up
+   $ docker-compose run --rm web ./scripts/populate-instance.sh
+   $ firefox http://127.0.0.1/
+
+Please note that populating the site with all example records is an optional
+step that may take considerable time (30 minutes or more).
 
 Appendix: Git workflow
 ======================

--- a/cernopendata/config.py
+++ b/cernopendata/config.py
@@ -33,8 +33,8 @@ from invenio_marc21.config import \
 from invenio_records_rest.facets import terms_filter
 
 # Static file
-# COLLECT_STORAGE = 'flask_collect.storage.file'
-COLLECT_STORAGE = 'flask_collect.storage.link'
+COLLECT_STORAGE = 'flask_collect.storage.file'
+# COLLECT_STORAGE = 'flask_collect.storage.link'
 
 # Cache
 CACHE_TYPE = 'redis'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -36,8 +36,6 @@ web:
     - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672/
     - APP_CELERY_RESULT_BACKEND=redis://redis:6379/2
     - APP_SEARCH_ELASTIC_HOSTS=elasticsearch
-  volumes:
-    - .:/code
   volumes_from:
     - static
   links:
@@ -62,8 +60,6 @@ worker:
     - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672/
     - APP_CELERY_RESULT_BACKEND=redis://redis:6379/2
     - APP_SEARCH_ELASTIC_HOSTS=elasticsearch
-  volumes:
-    - .:/code
   volumes_from:
     - static
   links:
@@ -117,6 +113,5 @@ static:
   restart: "no"
   build: .
   volumes:
-    - .:/code
     - /home/invenio/.virtualenvs/cernopendata/var/cernopendata-instance/static
   user: invenio

--- a/scripts/create-instance.sh
+++ b/scripts/create-instance.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -103,12 +103,14 @@ mkvirtualenv ${INVENIO_WEB_VENV}
 set -o errexit
 # set -o nounset
 
-pip install -e .
+# install development requirements:
+pip install -r requirements-devel.txt
+pip install -e .[all]
 
 # sphinxdoc-customise-instance-begin
 cdvirtualenv
 mkdir -p var/${INVENIO_WEB_INSTANCE}-instance/
-pip install jinja2-cli
+pip install jinja2-cli[yaml]
 echo '{}' | jinja2 ${scriptpathname}/instance.cfg > var/${INVENIO_WEB_INSTANCE}-instance/${INVENIO_WEB_INSTANCE}.cfg
 # sphinxdoc-customise-instance-end
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ install_requires = [
     'invenio-indexer>=1.0.0a1',
     'invenio-jsonschemas>=1.0.0a2',
     'invenio-marc21>=1.0.0a1',
-    'invenio-oaiserver>=1.0.0a9',
+    # FIXME invenio-oaiserver 1.0.0a10, 1.0.0a11 lead to functools32 troubles
+    'invenio-oaiserver>=1.0.0a9,<1.0.0a10',
     'invenio-pidstore>=1.0.0b1',
     'invenio-records-rest>=1.0.0a9',
     'invenio-records-ui>=1.0.0a8',


### PR DESCRIPTION
* Fixes installation procedure by including `jinja2-cli[yaml]` dependency option
  and by installing the necessary development-level packages.

* Removes Docker local volume mounting so that containers can be started on
  remote nodes via `docker-machine`.

* Switches collect storage to `file` instead of `link`, fixing static asset
  serving issues observed with Docker.

* Updates documentation with a concrete easy-to-follow Docker-based installation
  example.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
