### PR TITLE
installation: separate COD and Invenio development packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ cache:
 env:
   - REQUIREMENTS=lowest
   - REQUIREMENTS=release
-  - REQUIREMENTS=devel
+  - REQUIREMENTS=devel-cernopendata
+  - REQUIREMENTS=devel-all
 
 python:
   - "2.7"
@@ -50,7 +51,9 @@ before_install:
   - "travis_retry pip install twine wheel coveralls requirements-builder"
   - "requirements-builder --level=min setup.py > .travis-lowest-requirements.txt"
   - "requirements-builder --level=pypi setup.py > .travis-release-requirements.txt"
-  - "requirements-builder --level=dev --req requirements-devel.txt setup.py > .travis-devel-requirements.txt"
+  - "requirements-builder --level=dev --req requirements-devel-cernopendata.txt setup.py > .travis-devel-cernopendata-requirements.txt"
+  - "cat requirements-devel-cernopendata.txt requirements-devel-invenio.txt > /tmp/requirements-devel-all.txt"
+  - "requirements-builder --level=dev --req /tmp/requirements-devel-all.txt setup.py > .travis-devel-all-requirements.txt"
 
 install:
   - "travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt"

--- a/requirements-devel-cernopendata.txt
+++ b/requirements-devel-cernopendata.txt
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Open Data Portal.
+# Copyright (C) 2017 CERN.
+#
+# CERN Open Data Portal is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Open Data Portal is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Open Data Portal; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+-e git+https://github.com/cernopendata/cernopendata-theme.git#egg=cernopendata-theme
+-e git+https://github.com/cernopendata/cernopendata-pages.git#egg=cernopendata-pages

--- a/requirements-devel-invenio.txt
+++ b/requirements-devel-invenio.txt
@@ -22,8 +22,6 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
--e git+https://github.com/cernopendata/cernopendata-theme.git#egg=cernopendata-theme
--e git+https://github.com/cernopendata/cernopendata-pages.git#egg=cernopendata-pages
 -e git+https://github.com/inveniosoftware/flask-celeryext.git#egg=flask-celeryext
 -e git+https://github.com/inveniosoftware/invenio-assets.git#egg=invenio-assets
 -e git+https://github.com/inveniosoftware/invenio-base.git#egg=invenio-base

--- a/scripts/create-instance.sh
+++ b/scripts/create-instance.sh
@@ -103,8 +103,7 @@ mkvirtualenv ${INVENIO_WEB_VENV}
 set -o errexit
 # set -o nounset
 
-# install development requirements:
-pip install -r requirements-devel.txt
+# install CERN Open Data instance packages:
 pip install -e .[all]
 
 # sphinxdoc-customise-instance-begin


### PR DESCRIPTION
* Separates CERN Open Data and Invenio required development packages so that one
  can use e.g. bleeding edge CERN Open Data packages with PyPI-released Invenio
  packages for the overlay development.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>