### PR TITLE
installation: skip update of npm using npm

### DIFF
--- a/scripts/provision-web.sh
+++ b/scripts/provision-web.sh
@@ -135,7 +135,7 @@ provision_web_libpostgresql_centos7 () {
 setup_npm_and_css_js_filters () {
 
     # sphinxdoc-install-npm-and-css-js-filters-begin
-    $sudo su -c "npm install -g npm"
+    # $sudo su -c "npm install -g npm"
     $sudo su -c "npm install -g node-sass@3.8.0 clean-css@3.4.24 requirejs uglify-js"
     # sphinxdoc-install-npm-and-css-js-filters-end
 


### PR DESCRIPTION
* Skip npm update using npm to prevent access right problems
  with `npm install` -commands following the update.

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>