### PR TITLE
fixtures: collection and JSON data fixtures

### DIFF
--- a/cernopendata/modules/fixtures/__init__.py
+++ b/cernopendata/modules/fixtures/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Open Data Portal.
+# Copyright (C) 2017 CERN.
+#
+# CERN Open Data Portal is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Open Data Portal is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Fixtures for CERN Open Data Portal."""
+
+from __future__ import absolute_import, print_function

--- a/cernopendata/modules/fixtures/cli.py
+++ b/cernopendata/modules/fixtures/cli.py
@@ -1,0 +1,268 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Open Data Portal.
+# Copyright (C) 2017 CERN.
+#
+# CERN Open Data Portal is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Open Data Portal is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Command line interface for CERN Open Data Portal."""
+
+from __future__ import absolute_import, print_function
+
+import glob
+import json
+import os
+import uuid
+
+import click
+import pkg_resources
+from flask import current_app
+from flask.cli import with_appcontext
+from sqlalchemy.orm.attributes import flag_modified
+
+
+@click.group(chain=True)
+def fixtures():
+    """Automate site bootstrap process and testing."""
+
+
+@fixtures.command()
+@with_appcontext
+def collections():
+    """Load default collections."""
+    from invenio_db import db
+    from invenio_collections.models import Collection
+
+    from .fixtures import COLLECTIONS
+
+    def load(collections, parent=None):
+        """Create new collection."""
+        for data in collections or []:
+            collection = Collection(
+                name=data['name'], dbquery=data.get('dbquery'),
+                parent=parent
+            )
+            db.session.add(collection)
+            db.session.flush()
+            load(data.get('children'), parent=collection)
+
+    load(COLLECTIONS)
+    db.session.commit()
+
+
+@fixtures.command()
+@with_appcontext
+def records():
+    """Load demo records."""
+    from dojson.contrib.marc21.utils import load
+    from dojson.contrib.marc21.model import marc21
+    from invenio_db import db
+    from invenio_records import Record
+
+    class NoCheckRecord(Record):
+        """Skip record validation."""
+
+        def validate(self):
+            """Ignore schema."""
+            return True
+
+    schema = current_app.extensions['invenio-jsonschemas'].path_to_url(
+        'marc21/bibliographic/bd-v1.0.0.json'
+    )
+    data = pkg_resources.resource_filename('cernopendata',
+                                           'modules/fixtures/data')
+    files = list(glob.glob(os.path.join(data, '*.xml')))
+    files += list(glob.glob(os.path.join(data, '*', '*.xml')))
+
+    for filename in files:
+        with open(filename, 'rb') as source:
+            for data in load(source):
+                record = marc21.do(data)
+                record['$schema'] = schema
+                click.echo(NoCheckRecord.create(record).id)
+                db.session.commit()
+                db.session.expunge_all()
+
+
+@fixtures.command()
+@with_appcontext
+def terms():
+    """Load demo terms records."""
+    from invenio_db import db
+    from invenio_records import Record
+    from invenio_indexer.api import RecordIndexer
+    from cernopendata.modules.records.minters.termid import \
+        cernopendata_termid_minter
+
+    indexer = RecordIndexer()
+    schema = current_app.extensions['invenio-jsonschemas'].path_to_url(
+        'records/term-v1.0.0.json'
+    )
+    data = pkg_resources.resource_filename('cernopendata',
+                                           'modules/fixtures/data')
+    terms_json = glob.glob(os.path.join(data, 'terms', '*.json'))
+
+    for filename in terms_json:
+        with open(filename, 'rb') as source:
+            for data in json.load(source):
+                if "collections" not in data and \
+                   not isinstance(data.get("collections", None), basestring):
+                    data["collections"] = []
+                data["collections"].append({"primary": "Terms"})
+                id = uuid.uuid4()
+                cernopendata_termid_minter(id, data)
+                record = Record.create(data, id_=id)
+                record['$schema'] = schema
+                db.session.commit()
+                indexer.index(record)
+                db.session.expunge_all()
+
+
+@fixtures.command()
+@with_appcontext
+def news():
+    """Load demo news records."""
+    from invenio_db import db
+    from invenio_records import Record
+    from invenio_indexer.api import RecordIndexer
+    from cernopendata.modules.records.minters.artid import \
+        cernopendata_articleid_minter
+
+    indexer = RecordIndexer()
+    schema = current_app.extensions['invenio-jsonschemas'].path_to_url(
+        'records/article-v1.0.0.json'
+    )
+    data = pkg_resources.resource_filename('cernopendata',
+                                           'modules/fixtures/data')
+    articles_json = glob.glob(os.path.join(data, 'articles', 'news', '*.json'))
+
+    for filename in articles_json:
+        with open(filename, 'rb') as source:
+            for data in json.load(source):
+                if "collections" not in data and \
+                   not isinstance(data.get("collections", None), basestring):
+                    data["collections"] = []
+                data["collections"].append({"primary": "News"})
+                id = uuid.uuid4()
+                cernopendata_articleid_minter(id, data)
+                record = Record.create(data, id_=id)
+                record['$schema'] = schema
+                db.session.commit()
+                indexer.index(record)
+                db.session.expunge_all()
+
+
+@fixtures.command()
+@with_appcontext
+def data_policies():
+    """Load demo Data Policy records."""
+    from invenio_db import db
+    from invenio_records import Record
+    from invenio_indexer.api import RecordIndexer
+    from invenio_pidstore.errors import PIDDoesNotExistError, \
+        PersistentIdentifierError
+    from invenio_pidstore.models import PIDStatus, PersistentIdentifier
+    from invenio_pidstore.fetchers import recid_fetcher
+    from invenio_pidstore.minters import recid_minter
+    from cernopendata.modules.records.minters.recid import \
+        cernopendata_recid_minter
+
+    indexer = RecordIndexer()
+    schema = current_app.extensions['invenio-jsonschemas'].path_to_url(
+        'records/data-policies-v1.0.0.json'
+    )
+    data = pkg_resources.resource_filename('cernopendata',
+                                           'modules/fixtures/data')
+    data_policies_json = glob.glob(os.path.join(data, '*.json'))
+
+    for filename in data_policies_json:
+        with open(filename, 'rb') as source:
+            for data in json.load(source):
+                id = uuid.uuid4()
+                cernopendata_recid_minter(id, data)
+                record = Record.create(data, id_=id)
+                record['$schema'] = schema
+                db.session.commit()
+                indexer.index(record)
+                db.session.expunge_all()
+
+
+@fixtures.command()
+@with_appcontext
+def pids():
+    """Fetch and register PIDs."""
+    from invenio_db import db
+    from invenio_oaiserver.fetchers import oaiid_fetcher
+    from invenio_oaiserver.minters import oaiid_minter
+    from invenio_pidstore.errors import PIDDoesNotExistError, \
+        PersistentIdentifierError
+    from invenio_pidstore.models import PIDStatus, PersistentIdentifier
+    from invenio_pidstore.fetchers import recid_fetcher
+    from invenio_pidstore.minters import recid_minter
+    from invenio_records.models import RecordMetadata
+
+    recids = [r.id for r in RecordMetadata.query.all()]
+    db.session.expunge_all()
+
+    with click.progressbar(recids) as bar:
+        for record_id in bar:
+            record = RecordMetadata.query.get(record_id)
+            try:
+                pid = recid_fetcher(record.id, record.json)
+                found = PersistentIdentifier.get(
+                    pid_type=pid.pid_type,
+                    pid_value=pid.pid_value,
+                    pid_provider=pid.provider.pid_provider
+                )
+                click.echo('Found {0}.'.format(found))
+            except PIDDoesNotExistError:
+                db.session.add(
+                    PersistentIdentifier.create(
+                        pid.pid_type, pid.pid_value,
+                        object_type='rec', object_uuid=record.id,
+                        status=PIDStatus.REGISTERED
+                    )
+                )
+            except KeyError:
+                click.echo('Skiped: {0}'.format(record.id))
+                continue
+
+            pid_value = record.json.get('_oai', {}).get('id')
+            if pid_value is None:
+                assert 'control_number' in record.json
+                pid_value = current_app.config.get(
+                    'OAISERVER_ID_PREFIX'
+                ) + str(record.json['control_number'])
+
+                record.json.setdefault('_oai', {})
+                record.json['_oai']['id'] = pid.pid_value
+
+            pid = oaiid_fetcher(record.id, record.json)
+            try:
+                found = PersistentIdentifier.get(
+                    pid_type=pid.pid_type,
+                    pid_value=pid.pid_value,
+                    pid_provider=pid.provider.pid_provider
+                )
+                click.echo('Found {0}.'.format(found))
+            except PIDDoesNotExistError:
+                pid = oaiid_minter(record.id, record.json)
+                db.session.add(pid)
+
+            flag_modified(record, 'json')
+            assert record.json['_oai']['id']
+            db.session.add(record)
+            db.session.commit()
+            db.session.expunge_all()

--- a/cernopendata/modules/fixtures/data/articles/news/news.json
+++ b/cernopendata/modules/fixtures/data/articles/news/news.json
@@ -1,0 +1,52 @@
+[
+  {
+    "title": "Explore ATLAS Open Data resources",
+    "type": "html",
+    "body": "<p>Starting today, the data from 100 trillion proton collisions is now public on the Open Data Portal! This marks the world's first open release of 8 TeV data, gathered from the Large Hadron Collider in 2012.</p><p>Given its strong emphasis on learning, the release of ATLAS Open Data is accompanied by additional resources that are available via the ATLAS educational platform. The resources guide users through the data, explain how to visualise and how to download and use the data, and even provides open-source software. As part of this, ATLAS has made seven physics analyses available for users to get started with their research. By releasing additional resources and comprehensive documentation ATLAS aims at bridging the gap between phycisists and the public.</p>",
+    "collections": [
+      {"secondary": "ATLAS Collaboration"},
+      {"secondary": "ATLAS"}
+    ],
+    "created": "July 29th 2016"
+  },
+  {
+    "title": "CMS releases new batch of research data from LHC",
+    "type": "html",
+    "body": "<p>Today, the <a href=\"\">CMS Collaboration at CERN</a> has released more than <a href=\"http://opendata.cern.ch/search?ln=en&p=Run2011A+AND+collection%3ACMS-Primary-Datasets+OR+collection%3ACMS-Simulated-Datasets+OR+collection%3ACMS-Derived-Datasets\">300 terabytes (TB) of high-quality open data</a>. These include over 100 TB, or 2.5 inverse femtobarns (fb−1), of data from proton collisions at 7 TeV, making up half the data collected at the LHC by the CMS detector in 2011. This follows a previous release from November 2014, which made available around 27 TB of research data collected in 2010.</p><p>Available on the CERN Open Data Portal — which is built in collaboration with members of CERN’s IT Department and Scientific Information Service — the collision data are released into the public domain under the CC0 waiver and come in types: The so-called \"<a href=\"http://opendata.cern.ch/search?ln=en&p=Run2011A+AND+collection%3ACMS-Primary-Datasets\">primary datasets</a>\" are in the same format used by the CMS Collaboration to perform research. The \"<a href=\"http://opendata.cern.ch/search?ln=en&p=Run2011A+AND+collection%3ACMS-Derived-Datasets\">derived datasets</a>\" on the other hand require a lot less computing power and can be readily analysed by university or high-school students, and CMS has provided a limited number of datasets in this format. <a href=\"http://cms.web.cern.ch/news/cms-releases-new-batch-research-data-lhc\">Read full release announcement</a></p>",
+    "collections": [
+      {"secondary": "CMS Collaboration"},
+      {"secondary": "CMS"}
+    ],
+    "created": "April 22nd 2016"
+  },
+  {
+    "title": "ATLAS Higgs Machine Learning Challenge",
+    "type": "html",
+    "body": "<p>The dataset from the ATLAS Higgs Machine Learning Challenge has <a href=\"/collection/ATLAS-Higgs-Challenge-2014\">been released</a> on CERN Open Data Portal.</p><p><a href=\"http://www.atlas.ch/news/2014/are-you-up-for-higgs-challenge.html\">The Challenge</a>, which ran from May to September 2014, was to develop an algorithm that improved the detection of the Higgs boson signal. The <a href=\"http://www.atlas.ch/news/2013/higgs-into-fermions.html\">specific sample</a> used simulated Higgs particles into two tau particles inside the ATLAS detector. The downloadable sample was provided for participants at the host platform on Kaggle’s website. With almost 1,785 teams competing, the event was a huge success. Participants applied and developed cutting edge Machine Learning techniques, which have been shown to be better than existing traditional high-energy physics tools.</p><p>The dataset was removed at the end of the Challenge but due to high public demand, ATLAS as organiser of the event, has decided to house it in the CERN Open Data Portal where it will be available permanently. The 60MB zipped ASCII file can be decoded without a special software, and a few scripts are provided to help users get started. Detailed documentation for physicists and data scientists is also available. Thanks to the Digital Object Identifiers (DOIs) in CERN Open Data Portal, the dataset and accompanying material can be cited like any other paper.</p><p>The <a href=\"http://atlas.ch/news/2014/machine-learning-wins-the-higgs-challenge.html\">Challenge’s winner</a> Gábor Melis and recipients of the Special High Energy Physics meets Machine Learning Award, Tianqi Chen and Tong He, will be visiting CERN to deliver talks on their winning algorithms on 19 May.</p>",
+    "collections": [
+      {"secondary": "ATLAS Collaboration"},
+      {"secondary": "ATLAS"}
+    ],
+    "created": "February 17th 2015"
+  },
+  {
+    "title": "ALICE releases educational datasets",
+    "type": "html",
+    "body": "<p>ALICE is making a public release of a number of datasets customised for demonstration and educational purpose. A number of reconstructed data files which are not statistically representative are included to allow plotting transverse momentum and pseudorapidity distributions. More advanced analysis and tools as well as larger data samples will be available in future releases.</p><p>At this stage we are making available a set of outreach and educational analysis exercises. These are based on specifically-selected ALICE data and are widely used for the particle physics masterclasses. These exercises expose simplified tools, which however give the feel of the real tools employed by the physicists for the data analysis, and come in the form of analysis packages and small datasets organised as root files. Each analysis downloads on demand the required software and data from a common graphics interface.</p><p>The documentation coming with these exercises contains both some physics introduction and the instructions for running the programs, which highlight some of the ALICE physics. One exercise is the search for particles containing strange quarks, based on their V0 decays; the motivation is to give an insight to strangeness enhancement, one of the first signatures for the Quark-Gluon Plasma (QGP).  Another exercise basically looks at charged particle tracks; the aim is to calculate the nuclear modification factor RAA, by comparing particle yields in the case of lead-lead and proton-proton collisions; the fact that RAA is less than one indicates the suppression of charged particles due to interactions of partons with the QGP.</p>",
+    "collections": [
+      {"secondary": "ALICE Collaboration"},
+      {"secondary": "ALICE"}
+    ],
+    "created": "November 20th 2014"
+  },
+  {
+    "title": "CMS releases first batch of high-level LHC open data",
+    "type": "html",
+    "body": "<p>The Compact Muon Solenoid (CMS) Collaboration at CERN is excited to announce the public release of the first batch of high-level, analysable and open data from the Large Hadron Collider (LHC), recorded by the CMS detector. The datasets are available on the new CERN Open Data Portal and are being released into the public domain under the Creative Commons CC0 waiver, in keeping with CMS’s commitment to data preservation and open data. <a href=\"http://cms.web.cern.ch/news/cms-releases-first-batch-high-level-lhc-open-data\">Read full release announcement</a></p>",
+    "collections": [
+      {"secondary": "CMS Collaboration"},
+      {"secondary": "CMS"}
+    ],
+    "created": "November 20th 2014"
+  }
+]

--- a/cernopendata/modules/fixtures/data/data-policies-v1.0.0.json
+++ b/cernopendata/modules/fixtures/data/data-policies-v1.0.0.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "410",
+    "identifiers": [
+      {
+        "type": "DOI",
+        "id": "10.7483/OPENDATA.LHCb.HKJW.TWSZ"
+      }
+    ],
+    "title": "LHCb External Data Access Policy",
+    "collections": [
+      { "primary": "Data-Policies" }
+    ],
+    "authors": {
+      "name": "Clarke, Peter",
+      "affiliation": "U. Edinburgh"
+    },
+    "accelerator": "CERN LHC",
+    "experiment": "LHCb",
+    "description": "5 p",
+    "summary": "This document contains the LHCb Data Access Policy. This was adopted at the Collaboration Board meeting on 27th Feb 2013.",
+    "collaboration": "LHCb collaboration",
+    "_files": [
+      {
+        "type": "local",
+        "path": "/tmp/opendata.cern.ch-fft-file-cache/data-policies/LHCb-Data-Policy.pdf"
+      }
+    ],
+    "year": "2013",
+    "language": "eng",
+    "issued": {
+      "location": "Geneva",
+      "institute": "CERN",
+      "date": "22 Apr 2013"
+    },
+    "license": "CC0"
+  }
+]

--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -1,0 +1,580 @@
+[
+	{
+		"term": "AOD",
+		"anchor": "AOD",
+		"category": "specific",
+		"type": "0",
+		"definition": "Stands for “Analysis Object Data”, a format that contains all information needed for a CMS analysis. It contains reconstructed “physics objects” such as electrons, photons and muons.",
+		"experiment": [
+			{
+				"name": "CMS"
+			}
+		],
+		"see_also": [
+			{
+				"term": "primary"
+			},
+			{
+				"term": "reconstruction"
+			},
+			{
+				"term": "tag"
+			}
+		],
+		"links": [
+			{
+				"text": "Read more in the CMS WorkBook",
+				"url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookDataFormats#AoD"
+			},
+			{
+				"text": "Read more on the “About CMS” page on this portal",
+				"url": "http://opendata.cern.ch/about/CMS"
+			}
+		]
+	},
+	{
+		"term": "CMSSW",
+		"anchor": "CMSSW",
+		"category": "specific",
+		"type": "0",
+		"definition": "Stands for CMS Software and refers to (1) the so-called “Offline” software needed to simulate, reconstruct and analyse CMS data, and (2) the “Online” software needed for data selection and storage.",
+		"experiment": [
+			{
+				"name": "CMS"
+			}
+		],
+		"links": [
+			{
+				"text": "See the CMSSW codebase on GitHub",
+				"url": "https://github.com/cms-sw/cmssw"
+			}
+		],
+		"see_also": [
+			{
+				"term": "PAT"
+			}
+		]
+	},
+	{
+		"term": ["Derived Dataset","Derived Datasets"],
+		"anchor": "derived",
+		"category": "specific",
+		"type": "0",
+		"definition": "Contains data that have been derived from the primary datasets. The data may be reduced in the sense that (a) only part of the information is kept or (b) only part of the events are selected.",
+		"experiment": [
+			{
+				"name": "CMS"
+			},
+			{
+				"name": "ATLAS"
+			},
+			{
+				"name": "ALICE"
+			},
+			{
+				"name": "LHCb"
+			}
+		],
+		"see_also": [
+			{
+				"term": "primary"
+			},
+			{
+				"term": "tag"
+			},
+			{
+				"term": "condition"
+			}
+		],
+		"links": [
+			{
+				"text": "See all the “Derived datasets” collections on this portal",
+				"url": "http://opendata.cern.ch/search?ln=en&p=+%28collection%3AALICE-Derived-Datasets+OR+collection%3ACMS-Derived-Datasets+OR+collection%3AATLAS-Derived-Datasets+OR+collection%3ALHCb-Derived-Datasets%29&action_search="
+			}
+		]
+	},
+	{
+		"term": ["Electron","Electrons"],
+		"anchor": "electron",
+		"category": "generic",
+		"type": "0",
+		"definition": "A stable elementary particle belonging to the first generation of the “lepton” family of particles. It has a $-$1 electrical charge, while its anti-particle, the anti-electron or positron, has a +1 electrical charge. Atoms are made of electrons orbiting positively charged nuclei. An electron has a mass of ~0.5 MeV/c$^2$, or about 1/1836 times the mass of a proton.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Electron"
+			}
+		],
+		"see_also": [
+			{
+				"term": "muon"
+			},
+			{
+				"term": "proton"
+			},
+			{
+				"term": "neutrino"
+			}
+		]
+	},
+	{
+		"term": ["Event generator","Event generators","Generator","Generators"],
+		"anchor": "generator",
+		"category": "generic",
+		"type": "0",
+		"definition": "Simulation programs used to generate particle collisions.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Event_generator"
+			}
+		],
+		"see_also": [
+			{
+				"term": "montecarlo"
+			},
+			{
+				"term": "primary"
+			},
+			{
+				"term": "derived"
+			},
+			{
+				"term": "condition"
+			}
+		]
+	},
+	{
+		"term": ["Global Tag","Global Tags","Condition Data","Condition Database"],
+		"anchor": "tag",
+		"category": "specific",
+		"type": "0",
+		"definition": "A Global Tag is a coherent collection of records of additional data needed by the reconstruction and analysis software. These records are stored in the Condition Database. Condition data include non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for the simulation/reconstruction/analysis software.",
+		"experiment": [
+			{
+				"name": "CMS"
+			}
+		],
+		"links": [
+			{
+				"text": "Read more about CMS Global Tags",
+				"url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions"
+			}
+		],
+		"see_also": [
+			{
+				"term": "reconstruction"
+			},
+			{
+				"term": "AOD"
+			},
+			{
+				"term": "primary"
+			}
+		]
+	},
+	{
+		"term": ["Gluon","Gluons"],
+		"anchor": "gluon",
+		"category": "generic",
+		"type": "0",
+		"definition": "An elementary particle belonging to the “boson” family of particles. It is the carrier of the strong force that binds quarks together to form hadrons. It is massless and has no electrical charge but has a property known as “colour charge”.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Gluon"
+			}
+		],
+		"see_also": [
+			{
+				"term": "quark"
+			},
+			{
+				"term": "photon"
+			}
+		]
+	},
+	{
+		"term": ["Hadron","Hadrons"],
+		"anchor": "hadron",
+		"category": "generic",
+		"type": "0",
+		"definition": "A composite particle made of two or more quarks. There are two sub-categories of hadrons: “baryons” such as protons and neutrons are made of three quarks (or three anti-quarks), while “mesons” are made of a quark and an anti-quark. Atomic nuclei can also be considered hadrons, since they are also fundamentally made of quarks. The LHC collides two species of hadrons: protons and lead nuclei (also called lead ions). Hadrons produced in collisions typically cluster together to form particle jets in the detectors.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Hadron"
+			}
+		],
+		"see_also": [
+			{
+				"term": "proton"
+			},
+			{
+				"term": "quark"
+			},
+			{
+				"term": "jet"
+			},
+			{
+				"term": "ion"
+			}
+		]
+	},
+	{
+		"term": ["Ion","Ions"],
+		"anchor": "ion",
+		"category": "generic",
+		"type": "0",
+		"definition": "An ion is an atom or a molecule in which the number of electrons is not the same as the number of protons. In the context of the LHC, the term “heavy ion” refers to the nuclei of heavy atoms such as lead.",
+		"links": [
+			{
+				"text": "Read more about heavy-ion physics on the CERN website",
+				"url": "http://home.web.cern.ch/about/physics/heavy-ions-and-quark-gluon-plasma"
+			}
+		],
+		"see_also": [
+			{
+				"term": "proton"
+			},
+			{
+				"term": "quark"
+			},
+			{
+				"term": "jet"
+			},
+			{
+				"term": "ion"
+			}
+		]
+	},
+	{
+		"term": ["Lumi section","lumisection"],
+		"anchor": "lumisection",
+		"category": "specific",
+		"type": "0",
+	  "definition": "A lumi section is a fixed time period in data taking, approximately 24 seconds.",
+		"experiment": [
+			  {
+				"name": "CMS"
+			}
+		]
+	},
+	{
+		"term": ["Monte Carlo"],
+		"anchor": "montecarlo",
+		"category": "generic",
+		"type": "0",
+		"definition": "Refers to computational algorithms based on numerical random samplings that is used in simulation programs for generating the particle collisions and for simulating of particle interactions in the detector material. Often used as a synonym for simulated data.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Monte_Carlo_method"
+			}
+		],
+		"see_also": [
+			{
+				"term": "generator"
+			},
+			{
+				"term": "primary"
+			},
+			{
+				"term": "derived"
+			},
+			{
+				"term": "condition"
+			}
+		]
+	},
+	{
+		"term": ["Muon","Muons"],
+		"anchor": "muon",
+		"type": "0",
+		"category": "generic",
+    "definition": "An elementary particle belonging to the second generation of the “lepton” family of particles. It has a $-$1 electrical charge, while its anti-particle, the anti-muon, has a +1 electrical charge. A muon’s properties are similar to those of an electron but it is around 200 times more massive. It is represented by the Greek letter “$\\mu$”.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Muon"
+			}
+		],
+		"see_also": [
+			{
+				"term": "electron"
+			},
+			{
+				"term": "neutrino"
+			}
+		]
+	},
+	{
+		"term": ["Neutrino","Neutrinos"],
+		"anchor": "neutrino",
+		"category": "generic",
+		"type": "0",
+		"definition": "An elementary particle belonging to the “lepton” family of particles. Neutrinos and their anti-particles, anti-neutrinos, have no charge, although measurements show that they are not massless. Neutrinos rarely interact with matter: they can fly through lightyears of lead without coming to a stop. Therefore, they cannot be detected directly by the particle detectors at the LHC: their presence has to be inferred by detecting and measuring every other particle produced in the collisions and then applying conservation laws. Neutrinos are recorded as “missing transverse energy” or MET, although MET could also be a sign of previously undiscovered, non-interacting particles.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Neutrino"
+			}
+		],
+		"see_also": [
+			{
+				"term": "muon"
+			},
+			{
+				"term": "neutrino"
+			}
+		]
+	},
+	{
+		"term": ["Particle jet","Particle jets"],
+		"anchor": "jet",
+		"category": "generic",
+		"type": "0",
+		"definition": "A jet is a shower of hadrons, which originate from a quark or a gluon, clustered together after being produced in particle collisions.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Jet_%28particle_physics%29"
+			}
+		],
+		"see_also": [
+			{
+				"term": "proton"
+			},
+			{
+				"term": "quark"
+			},
+			{
+				"term": "hadron"
+			}
+		]
+	},
+	{
+		"term": "PAT",
+		"anchor": "PAT",
+		"category": "specific",
+		"type": "0",
+		"definition": "Stands for Physics Analysis Toolkit, and provides easy access to algorithms developed by the CMS Physics Object Groups (POGs) in the framework of CMS Software (CMSSW), suitable for most CMS analyses.",
+		"experiment": [
+			{
+				"name": "CMS"
+			}
+		],
+		"see_also": [
+			{
+				"term": "CMSSW"
+			}
+		],
+		"links": [
+			{
+				"text": "Read more in the CMS Software guide",
+				"url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePAT"
+			}
+		]
+	},
+	{
+		"term": ["Photon","Photons"],
+		"anchor": "photon",
+		"category": "generic",
+		"type": "0",
+    "definition": "A stable elementary particle belonging to the “boson” family of particles. Called the “quantum” of light, the photon is the carrier of the electromagnetic force and is massless with no electrical charge. It is represented by the Greek letter “$\\gamma$”.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Photon"
+			}
+		],
+		"see_also": [
+			{
+				"term": "gluon"
+			}
+		]
+	},
+	{
+		"term": ["Primary Dataset","Primary Datasets"],
+		"anchor": "primary",
+		"definition": "Datasets prepared after trigger selections, with no further selection criteria applied. On this portal, primary datasets refer to “reconstructed data”.",
+		"type": "0",
+		"category": "specific",
+		"experiment": [
+			{
+				"name": "CMS"
+			},
+			{
+				"name": "ATLAS"
+			},
+			{
+				"name": "ALICE"
+			},
+			{
+				"name": "LHCb"
+			}
+		],
+		"see_also": [
+			{
+				"term": "AOD"
+			},
+			{
+				"term": "reconstruction"
+			},
+			{
+				"term": "tag"
+			},
+			{
+				"term": "derived"
+			},
+			{
+				"term": "trigger"
+			},
+			{
+				"term": "condition"
+			}
+		],
+		"links": [
+			{
+				"text": "Read more on the CMS website",
+				"url": "http://cern.ch/cms"
+			}
+		]
+	},
+	{
+		"term": ["Proton","Protons"],
+		"anchor": "proton",
+		"category": "generic",
+		"type": "0",
+		"definition": "A stable composite particle belonging to the “hadron” family of particles, made of two up quarks and a down quark. It has a +1 electrical charge and is found in the nuclei of atoms. A proton has a mass of ~938 MeV/c<sup>2</sup>, or about 1836 times the mass of an electron. Protons are one of the species of particles collided at the LHC.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Proton"
+			}
+		],
+		"see_also": [
+			{
+				"term": "hadron"
+			},
+			{
+				"term": "electron"
+			},
+			{
+				"term": "jet"
+			}
+		]
+	},
+	{
+		"term": ["Quark","Quarks"],
+		"anchor": "quark",
+		"category": "generic",
+		"type": "0",
+		"definition": "An elementary particle that comes in six flavours: up, charm and top (all with +2/3 electrical charge) and down, strange and bottom (all with $-$1/3 electrical charge). Quarks also have a property known as “colour charge” and cannot exist freely because of a phenomenon called “colour confinement”: they are held together by gluons to form hadrons.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Quark"
+			}
+		],
+		"see_also": [
+			{
+				"term": "hadron"
+			},
+			{
+				"term": "proton"
+			},
+			{
+				"term": "jet"
+			},
+			{
+				"term": "gluon"
+			}
+		]
+	},
+	{
+		"term": ["Reconstruction","Reconstructions"],
+		"anchor": "reconstruction",
+		"definition": "Fragmented data from various sub-detectors are processed or “reconstructed” to provide coherent information about individual physics objects such as electrons or particle jets. Reconstruction involves putting together information from different sub-detectors into a coherent representation of every particle collision. However, the format for the first tier of reconstructed data is often too huge for meaningful analysis, and is converted into a lighter format, such as the AOD format for CMS.",
+		"type": "0",
+		"category": "specific",
+		"experiment": [
+			{
+				"name": "CMS"
+			},
+			{
+				"name": "ATLAS"
+			},
+			{
+				"name": "ALICE"
+			},
+			{
+				"name": "LHCb"
+			}
+		],
+		"see_also": [
+			{
+				"term": "AOD"
+			},
+			{
+				"term": "primary"
+			},
+			{
+				"term": "tag"
+			}
+		],
+		"links": [
+			{
+				"text": "Read more in the CMS WorkBook",
+				"url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookDataFormats#RecO"
+			}
+		]
+	},
+	{
+		"term": ["Physics Run","RunA","RunB","RunC","RunD","Run2010A","Run2010B","Run2011A","Run2011B","Run2012A","Run2012B","Run2012C","Run2012D"],
+		"anchor": "Run",
+		"type": "0",
+		"category": "specific",
+		"definition": "The data collected by CMS in a given year are divided into sets called “Runs”. For example, the data from 2010 were divided into “RunA” and “RunB”, the latter being from the second part of the year.",
+		"experiment": [
+			{
+				"name": "CMS"
+			}
+		],
+		"see_also": [
+			{
+				"term": "AOD"
+			}
+		],
+		"links": [
+			{
+				"text": "Read more about CMS Luminosity records",
+				"url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/LumiPublicResults"
+			}
+		]
+	},
+	{
+		"term": ["Trigger","Triggers","L1","HLT"],
+		"anchor": "trigger",
+		"category": "generic",
+		"type": "0",
+		"definition": "A system that determines which particle collisions are stored in primary datasets and which ones are discarded. The triggering is done first by a lower-level hardware-based trigger (L1) and then by the High-Level Trigger (HLT) on a computing farm.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Trigger_%28particle_physics%29"
+			}
+		],
+		"see_also": [
+			{
+				"term": "generator"
+			},
+			{
+				"term": "primary"
+			},
+			{
+				"term": "derived"
+			}
+		]
+	}
+]

--- a/cernopendata/modules/fixtures/fixtures.py
+++ b/cernopendata/modules/fixtures/fixtures.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Open Data Portal.
+# Copyright (C) 2012, 2013, 2014, 2015, 2016 CERN.
+#
+# CERN Open Data Portal is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Open Data Portal is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Define fixtures."""
+
+COLLECTIONS = [dict(
+    name='CERN Open Data Portal',
+    dbquery=None,
+    children=[dict(
+        name='CMS',
+        dbquery=None,
+        children=[dict(
+            name='CMS-Primary-Datasets',
+            dbquery='collections.primary:"CMS-Primary-Datasets"',
+        ), dict(
+            name='CMS-Derived-Datasets',
+            dbquery='collections.primary:"CMS-Derived-Datasets"',
+        ), dict(
+            name='CMS-Tools',
+            dbquery='collections.primary:"CMS-Tools"',
+        ), dict(
+            name='CMS-Validated-Runs',
+            dbquery='collections.primary:"CMS-Validated-Runs"',
+        ), dict(
+            name='CMS-Learning-Resources',
+            dbquery='collections.primary:"CMS-Learning-Resources"',
+        ), dict(
+            name='CMS-Open-Data-Instructions',
+            dbquery='collections.primary:"CMS-Open-Data-Instructions"',
+        ),
+        ],
+    ), dict(
+        name='ALICE',
+        dbquery=None,
+        children=[dict(
+            name='ALICE-Derived-Datasets',
+            dbquery='collections.primary:"ALICE-Derived-Datasets"',
+        ), dict(
+            name='ALICE-Tools',
+            dbquery='collections.primary:"ALICE-Tools"',
+        ), dict(
+            name='ALICE-Reconstructed-Data',
+            dbquery='collections.primary:"ALICE-Reconstructed-Data"',
+        ), dict(
+            name='ALICE-Learning-Resources',
+            dbquery='collections.primary:"ALICE-Learning-Resources"',
+        ),
+        ],
+    ), dict(
+        name='ATLAS',
+        dbquery=None,
+        children=[dict(
+            name='ATLAS-Derived-Datasets',
+            dbquery='collections.primary:"ATLAS-Derived-Datasets"',
+        ), dict(
+            name='ATLAS-Learning-Resources',
+            dbquery='collections.primary:"ATLAS-Learning-Resources"',
+        ), dict(
+            name='ATLAS-Tools',
+            dbquery='collections.primary:"ATLAS-Tools"',
+        ), dict(
+            name='ATLAS-Higgs-Challenge-2014',
+            dbquery='collections.primary:"ATLAS-Higgs-Challenge-2014"',
+        ),
+        ],
+    ), dict(
+        name='LHCb',
+        dbquery=None,
+        children=[dict(
+            name='LHCb-Derived-Datasets',
+            dbquery='collections.primary:"LHCb-Derived-Datasets"',
+        ), dict(
+            name='LHCb-Tools',
+            dbquery='collections.primary:"LHCb-Tools"',
+        ), dict(
+            name='LHCb-Learning-Resources',
+            dbquery='collections.primary:"LHCb-Learning-Resources"',
+        ),
+        ],
+    ), dict(
+        name='Author-Lists',
+        dbquery='collections.primary:"Author-Lists"',
+    ), dict(
+        name='Data-Policies',
+        dbquery='collections.primary:"Data-Policies"',
+    ),
+    ],
+),
+]

--- a/cernopendata/modules/fixtures/rules.py
+++ b/cernopendata/modules/fixtures/rules.py
@@ -1,0 +1,96 @@
+"""CERN Open Data custom fields of MARC 21 model."""
+
+from dojson import utils
+from dojson.contrib.marc21.model import marc21
+
+
+@marc21.over('269', '^269__')
+@utils.filter_values
+def field_269(self, key, value):
+    """269 field."""
+    field_map = {
+        'a': 'a',
+        'b': 'b',
+        'c': 'c',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    return {
+        '__order__': tuple(order) if len(order) else None,
+        'a': value.get('a'),
+        'b': value.get('b'),
+        'c': value.get('c'),
+    }
+
+
+@marc21.over('593', '^593__')
+@utils.filter_values
+def field_593(self, key, value):
+    """593 field."""
+    field_map = {
+        'a': 'a',
+        'b': 'b',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    return {
+        '__order__': tuple(order) if len(order) else None,
+        'a': value.get('a'),
+        'b': value.get('b'),
+    }
+
+
+@marc21.over('693', '^693[_1]_')
+@utils.filter_values
+def accelerator_experiment(self, key, value):
+    """Accelerator experiment."""
+    return {
+        'accelerator': value.get('a'),
+        'experiment': value.get('e'),
+    }
+
+
+@marc21.over('beam_energy', '^942__')
+def collision_energy(self, key, value):
+    """Collision energy."""
+    return value.get('a')
+
+
+@marc21.over('reprocessing_date', '^960__')
+def reprocessing_date(self, key, value):
+    """Reprocessing date."""
+    return value.get('c')
+
+
+@marc21.over('accelerator_run', '^964_[_0]')
+def accelerator_run(self, key, value):
+    """Accelerator run."""
+    return value.get('c')
+
+
+@marc21.over('files', '^FFT__')
+@utils.for_each_value
+@utils.filter_values
+def fft_files(self, key, value):
+    """593 field."""
+    field_map = {
+        'z': 'comment',
+        'y': 'description',
+        'q': 'eformat',
+        'f': 'name',
+        's': 'size',
+        'u': 'url',
+    }
+    order = utils.map_order(field_map, value)
+
+    return {
+        '__order__': tuple(order) if len(order) else None,
+        'comment': value.get('z'),
+        'description': value.get('y'),
+        'eformat': value.get('q'),
+        'name': value.get('f'),
+        'size': value.get('s'),
+        'url': value.get('u'),
+    }

--- a/requirements-devel-cernopendata.txt
+++ b/requirements-devel-cernopendata.txt
@@ -22,6 +22,4 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
--e git+https://github.com/cernopendata/cernopendata-fixtures.git#egg=cernopendata-fixtures
-
 -e .[all]

--- a/scripts/populate-instance.sh
+++ b/scripts/populate-instance.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -117,12 +117,10 @@ sleep 20
 # sphinxdoc-create-user-account-end
 
 # sphinxdoc-populate-with-demo-records-begin
-pip install -e git+https://github.com/cernopendata/cernopendata-fixtures.git#egg=cernopendata-fixtures
 ${INVENIO_WEB_INSTANCE} fixtures collections
 ${INVENIO_WEB_INSTANCE} fixtures records
 ${INVENIO_WEB_INSTANCE} fixtures pids
 ${INVENIO_WEB_INSTANCE} fixtures terms
-pip uninstall -y cernopendata-fixtures
 # sphinxdoc-populate-with-demo-records-end
 
 # sphinxdoc-index-all-records-begin

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,10 @@ setup(
         'dojson.contrib.marc21': [
             'cernopendata = cernopendata.rules',
         ],
+        'flask.commands': [
+            'fixtures = '
+            'cernopendata.modules.fixtures.cli:fixtures',
+        ],
         'invenio_assets.bundles': [
             'cernopendata_theme_css = cernopendata.modules.theme.bundles:css',
             'cernopendata_search_js = cernopendata.modules.theme.bundles'


### PR DESCRIPTION
* Adds collection, terms, news articles, and data policy fixtures from the
  standalone `cernopendata-fixtures` repository.  Does not add MARC21 record
  fixtures as they will be soon replaced by their non-MARC counterparts.

* This commit cherry-picks code from the `cernopendata-fixtures` repository
  that was authored by Ioannis, Jiri, and Pamfilos and amends it as necessary
  by the package move.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
Co-authored-by: Ioannis Tsanaktsidis <ioannis.tsanaktsidis@cern.ch>
Co-authored-by: Jiri Kuncar <jiri.kuncar@cern.ch>
Co-authored-by: Pamfilos Fokianos <pamfilosf@gmail.com>